### PR TITLE
Remove roave/security-advisories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,6 @@
     "php-stubs/wordpress-stubs": "^6.8",
     "phpcompatibility/php-compatibility": "*",
     "rector/rector": "^2.1",
-    "roave/security-advisories": "dev-latest",
     "roots/wordpress": "^6.8",
     "slevomat/coding-standard": "~8.18",
     "squizlabs/php_codesniffer": "^3.2",


### PR DESCRIPTION
Because of https://github.com/Roave/SecurityAdvisories/pull/132